### PR TITLE
Enhance TickTick project fetching with optional filtering

### DIFF
--- a/frontend/src/components/Dashboard/Recent/TickTickActivityMeta.tsx
+++ b/frontend/src/components/Dashboard/Recent/TickTickActivityMeta.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import { Calendar, Clock, Tag, List, ArrowRightLeft, Cloud } from 'lucide-react';
 
 interface TickTickMetadata {

--- a/frontend/src/contexts/TasksContext.tsx
+++ b/frontend/src/contexts/TasksContext.tsx
@@ -102,10 +102,7 @@ export function TasksProvider({ children }: { children: React.ReactNode }) {
 
   useEffect(() => {
     fetchTasks();
-    if (isTickTickConnected && tickTickProjectId) {
-      fetchTickTickTasks();
-    }
-  }, [fetchTasks, fetchTickTickTasks, isTickTickConnected, tickTickProjectId]);
+  }, [fetchTasks, isTickTickConnected, tickTickProjectId]);
 
   // Add a separate effect to check TickTick connection status on mount and when auth changes
   useEffect(() => {

--- a/frontend/src/services/api/integrations.service.ts
+++ b/frontend/src/services/api/integrations.service.ts
@@ -79,10 +79,12 @@ export const integrationsService = {
 
     /**
      * Fetch TickTick projects available for the connected user.
+     * @param kind Optional filter for project kind (e.g., "TASK", "NOTE")
      */
-    async getTickTickProjects(): Promise<{ id: string; name: string; color?: string; }[]> {
+    async getTickTickProjects(kind?: string): Promise<{ id: string; name: string; color?: string; kind?: string; }[]> {
         try {
-            const response = await api.get('/api/integrations/ticktick/projects');
+            const endpoint = kind ? `/api/integrations/ticktick/projects?kind=${kind}` : '/api/integrations/ticktick/projects';
+            const response = await api.get(endpoint);
             return response.data;
         } catch (error) {
             console.error('Error fetching TickTick projects:', error);


### PR DESCRIPTION
- Updated `GetTickTickProjects` method in `IntegrationsController` to accept an optional `kind` query parameter for filtering projects by type.
- Improved logging to include the kind filter used during project retrieval.
- Modified frontend components to utilize the new filtering capability, ensuring only relevant projects are fetched based on the specified kind.
- Introduced local type definition for `TickTickProject` in `TasksPage` for better type safety and clarity.
- Enhanced state management in `TasksPage` to handle project fetching and updates more efficiently.