### PR TITLE
Update README TickTick redirect URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ Configure the `.env` file with the appropriate API URLs and TickTick credentials
 ```plaintext
 # Example .env entries
 VITE_TICKTICK_CLIENT_ID=your_ticktick_client_id
-VITE_TICKTICK_REDIRECT_URI=http://localhost:5173/dashboard/callback/ticktick
+VITE_TICKTICK_REDIRECT_URI=http://localhost:5173/callback/ticktick
 ```
 
 ### Backend Setup


### PR DESCRIPTION
## Summary
- update VITE_TICKTICK_REDIRECT_URI example to use `/callback/ticktick`

------
https://chatgpt.com/codex/tasks/task_e_6840d6c86c648328b1a859bb2c8d16da